### PR TITLE
Package

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,6 +16,8 @@ module.exports = function(gulp, opts) {
     opts = {};
   }
 
+  var packageFile = options.packageFile || 'package.json';
+
   gulp.task('clean', function(cb) {
     del(['./dist', './dist.zip'], cb);
   });
@@ -31,13 +33,13 @@ module.exports = function(gulp, opts) {
   });
 
   gulp.task('node-mods', function() {
-    return gulp.src('./package.json')
+    return gulp.src('./' + packageFile)
       .pipe(gulp.dest('dist/'))
       .pipe(install({production: true, ignoreScripts: opts.ignoreScripts}));
   });
 
   gulp.task('zip', function() {
-    return gulp.src(['dist/**/*', '!dist/package.json'])
+    return gulp.src(['dist/**/*', '!dist/' + packageFile])
       .pipe(zip('dist.zip'))
       .pipe(gulp.dest('./'));
   });

--- a/index.js
+++ b/index.js
@@ -4,6 +4,7 @@ var del = require('del');
 var install = require('gulp-install');
 var runSequence = require('run-sequence');
 var AWS = require('aws-sdk');
+var rename = require("gulp-rename");
 var fs = require('fs');
 
 module.exports = function(gulp, opts) {
@@ -34,6 +35,7 @@ module.exports = function(gulp, opts) {
 
   gulp.task('node-mods', function() {
     return gulp.src('./' + packageFile)
+      .pipe(rename('package.json'))
       .pipe(gulp.dest('dist/'))
       .pipe(install({production: true, ignoreScripts: opts.ignoreScripts}));
   });

--- a/index.js
+++ b/index.js
@@ -16,7 +16,7 @@ module.exports = function(gulp, opts) {
     opts = {};
   }
 
-  var packageFile = options.packageFile || 'package.json';
+  var packageFile = opts.packageFile || 'package.json';
 
   gulp.task('clean', function(cb) {
     del(['./dist', './dist.zip'], cb);

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "gulp-install": "^0.4.0",
     "gulp-util": "^3.0.4",
     "gulp-zip": "^3.0.2",
+    "gulp-rename": "1.2.2",
     "run-sequence": "^1.0.2"
   },
   "peerDependencies": {


### PR DESCRIPTION
Because I have a local folder with common code shared across each lambda function, relative file paths don't work because npm install is invoked relative to dist directory, ie: 

```
"common": "file:../common/"
```

In an ideal world, the plugin would either write file paths, or, I put the common code in a real module somewhere. To get around it, i create a package-aws.json, that uses a diff relative path.
